### PR TITLE
use "golang.org/x/net/context" for now to make reviewdog buildable in pre go 1.7

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"crypto/tls"
 	"errors"
 	"flag"
@@ -16,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+
+	"golang.org/x/net/context" // "context"
 
 	"golang.org/x/oauth2"
 


### PR DESCRIPTION
ref: #43