### PR TITLE
Bump up version to 0.9.4

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -28,6 +28,8 @@ import (
 	"github.com/mattn/go-shellwords"
 )
 
+const version = "0.9.4"
+
 const usageMessage = "" +
 	`Usage:	reviewdog [flags]
 	reviewdog accepts any compiler or linter results from stdin and filters
@@ -36,6 +38,7 @@ const usageMessage = "" +
 `
 
 type option struct {
+	version   bool
 	diffCmd   string
 	diffStrip int
 	efms      strslice
@@ -78,6 +81,7 @@ const (
 var opt = &option{}
 
 func init() {
+	flag.BoolVar(&opt.version, "version", false, "print version")
 	flag.StringVar(&opt.diffCmd, "diff", "", diffCmdDoc)
 	flag.IntVar(&opt.diffStrip, "strip", 1, diffStripDoc)
 	flag.Var(&opt.efms, "efm", efmsDoc)
@@ -106,6 +110,11 @@ func main() {
 
 func run(r io.Reader, w io.Writer, opt *option) error {
 	ctx := context.Background()
+
+	if opt.version {
+		fmt.Fprintln(w, version)
+		return nil
+	}
 
 	if opt.list {
 		return runList(w)

--- a/cmd/reviewdog/main_test.go
+++ b/cmd/reviewdog/main_test.go
@@ -461,3 +461,13 @@ func TestCommonci(t *testing.T) {
 	}
 
 }
+
+func TestRun_version(t *testing.T) {
+	stdout := new(bytes.Buffer)
+	if err := run(nil, stdout, &option{version: true}); err != nil {
+		t.Error(err)
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != version {
+		t.Errorf("version = %v, want %v", got, version)
+	}
+}


### PR DESCRIPTION
## [0.9.4](https://github.com/haya14busa/reviewdog/compare/0.9.3...0.9.4) (2016-12-16)

* vendoring with git submodule [#57](https://github.com/haya14busa/reviewdog/pull/57) ([haya14busa](https://github.com/haya14busa))
* Improve CI [#64](https://github.com/haya14busa/reviewdog/pull/64) ([haya14busa](https://github.com/haya14busa))
* Introduce GitHub pull reviews api [#63](https://github.com/haya14busa/reviewdog/pull/63) ([haya14busa](https://github.com/haya14busa))
* introduce go-simple [#62](https://github.com/haya14busa/reviewdog/pull/62) ([haya14busa](https://github.com/haya14busa))
* Use os.Unsetenv() instead of os.Setenv(key, "") [#61](https://github.com/haya14busa/reviewdog/pull/61) ([haya14busa](https://github.com/haya14busa))
