### PR TITLE
using environment proxy setting.

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -261,6 +261,7 @@ func githubService(ctx context.Context, ci string) (githubservice *reviewdog.Git
 
 func githubClient(ctx context.Context, token string) (*github.Client, error) {
 	tr := &http.Transport{
+		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify()},
 	}
 	sslcli := &http.Client{Transport: tr}


### PR DESCRIPTION
hi.
revewdog is amazing product.

I want using in office.
but reviewdog not working, because my office network in under proxy.

please, use environment proxy setting (http.ProxyFromEnvironment)  like the http.DefaultClient.
