### PR TITLE
Add command name prefix to error message

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -103,7 +103,7 @@ func main() {
 	flag.Usage = usage
 	flag.Parse()
 	if err := run(os.Stdin, os.Stdout, opt); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintf(os.Stderr, "reviewdog: %v\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
I think it's better to add the command prefix for error messages so that we can tell where the error messages come from.