### PR TITLE
add trailing slash to GitHub default BaseURL

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -276,7 +276,7 @@ func githubClient(ctx context.Context, token string) (*github.Client, error) {
 	return client, err
 }
 
-const defaultGitHubAPI = "https://api.github.com"
+const defaultGitHubAPI = "https://api.github.com/"
 
 func githubBaseURL() (*url.URL, error) {
 	baseURL := os.Getenv("GITHUB_API")


### PR DESCRIPTION
The update of https://github.com/google/go-github/pull/692 doesn't allow to use GitHub API Base URL without trailing slash.

```
$ go get -u github.com/haya14busa/reviewdog/cmd/reviewdog
$ reviewdog -ci="circle-ci"
$ reviewdog: fail to run reviewdog: fail to get diff: BaseURL must have a trailing slash, but "https://api.github.com" does not
```