### PR TITLE
Improve repo name/owner in drone.io

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -384,15 +384,14 @@ func droneio() (g *GitHubPR, isPR bool, err error) {
 	if err != nil {
 		return nil, true, fmt.Errorf("unexpected env variable (DRONE_PULL_REQUEST): %v", prs)
 	}
-	reposlug, err := nonEmptyEnv("DRONE_REPO") // e.g. haya14busa/reviewdog
+	owner, err := nonEmptyEnv("DRONE_REPO_OWNER")
 	if err != nil {
 		return nil, true, err
 	}
-	rss := strings.SplitN(reposlug, "/", 2)
-	if len(rss) < 2 {
-		return nil, true, fmt.Errorf("unexpected env variable. DRONE_REPO=%v", reposlug)
+	repo, err := nonEmptyEnv("DRONE_REPO_NAME")
+	if err != nil {
+		return nil, true, err
 	}
-	owner, repo := rss[0], rss[1]
 	sha, err := nonEmptyEnv("DRONE_COMMIT")
 	if err != nil {
 		return nil, true, err

--- a/cmd/reviewdog/main_test.go
+++ b/cmd/reviewdog/main_test.go
@@ -315,6 +315,8 @@ func TestDroneio(t *testing.T) {
 	envs := []string{
 		"DRONE_PULL_REQUEST",
 		"DRONE_REPO",
+		"DRONE_REPO_OWNER",
+		"DRONE_REPO_NAME",
 		"DRONE_COMMIT",
 		"REVIEWDOG_GITHUB_API_TOKEN",
 	}
@@ -349,19 +351,35 @@ func TestDroneio(t *testing.T) {
 		t.Log(err)
 	}
 
+	// Drone <= 0.4 without valid repo
 	os.Setenv("DRONE_REPO", "invalid")
 	if _, _, err := droneio(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
+	os.Unsetenv("DRONE_REPO")
 
-	os.Setenv("DRONE_REPO", "haya14busa/reviewdog")
+	// Drone > 0.4 without DRONE_REPO_NAME
+	os.Setenv("DRONE_REPO_OWNER", "haya14busa")
 	if _, _, err := droneio(); err == nil {
 		t.Error("error expected but got nil")
 	} else {
 		t.Log(err)
 	}
+	os.Unsetenv("DRONE_REPO_OWNER")
+
+	// Drone > 0.4 without DRONE_REPO_OWNER
+	os.Setenv("DRONE_REPO_NAME", "reviewdog")
+	if _, _, err := droneio(); err == nil {
+		t.Error("error expected but got nil")
+	} else {
+		t.Log(err)
+	}
+
+	// Drone > 0.4 have valid variables
+	os.Setenv("DRONE_REPO_NAME", "reviewdog")
+	os.Setenv("DRONE_REPO_OWNER", "haya14busa")
 
 	os.Setenv("DRONE_COMMIT", "sha1")
 	g, isPR, err := droneio()


### PR DESCRIPTION
Since Drone.IO have `DRONE_REPO_OWNER` and `DRONE_REPO_NAME` env variables we should use it to identify GH repo instead of split `DRONE_REPO` string.

Refs http://docs.drone.io/environment-reference/