### PR TITLE
Fix GITHUB_API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Export the token environment variable by secure way, depending on CI services.
 For GitHub Enterprise, please set API endpoint by environment variable.
 
 ```
-export GITHUB_API="https://example.githubenterprise.com/api/v3"
+export GITHUB_API="https://example.githubenterprise.com/api/v3/"
 ```
 
 #### Supported CI services


### PR DESCRIPTION
Hello.

Note that currently, [defaultGithub](https://github.com/haya14busa/reviewdog/blob/master/cmd/reviewdog/main.go#L279) is `https://api.github.com/`.
Therefore `GITHUB_API` must be the same. (end with `/`')

