### PR TITLE
doghouse: add branch field

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ You can use reviewdog to post review comments anywhere with following environmen
 | `CI_COMMIT`       | SHA1 for the current build |
 | `CI_REPO_OWNER`   | repository owner (e.g. "haya14busa" for https://github.com/haya14busa/reviewdog) |
 | `CI_REPO_NAME`    | repository name (e.g. "reviewdog" for https://github.com/haya14busa/reviewdog) |
+| `CI_BRANCH`       | [optional] branch of the commit |
 | `REVIEWDOG_GITHUB_API_TOKEN`    | GitHub Personal API Access token |
 
 ```sh

--- a/cienv/cienv.go
+++ b/cienv/cienv.go
@@ -15,6 +15,9 @@ type PullRequestInfo struct {
 	Repo        string
 	PullRequest int
 	SHA         string
+
+	// Optional.
+	Branch string
 }
 
 // GetPullRequestInfo returns PullRequestInfo from environment variables.
@@ -66,11 +69,19 @@ func GetPullRequestInfo() (prInfo *PullRequestInfo, isPR bool, err error) {
 		return nil, false, errors.New("cannot get commit SHA from environment variable. Set CI_COMMIT?")
 	}
 
+	branch := getOneEnvValue([]string{
+		"CI_BRANCH", // common
+		"TRAVIS_PULL_REQUEST_BRANCH",
+		"CIRCLE_BRANCH",
+		"DRONE_COMMIT_BRANCH",
+	})
+
 	return &PullRequestInfo{
 		Owner:       owner,
 		Repo:        repo,
 		PullRequest: pr,
 		SHA:         sha,
+		Branch:      branch,
 	}, true, nil
 }
 

--- a/cienv/cienv_test.go
+++ b/cienv/cienv_test.go
@@ -24,6 +24,10 @@ func setupEnvs() (cleanup func()) {
 		"CI_COMMIT",
 		"CI_REPO_OWNER",
 		"CI_REPO_NAME",
+		"CI_BRANCH",
+		"TRAVIS_PULL_REQUEST_BRANCH",
+		"CIRCLE_BRANCH",
+		"DRONE_COMMIT_BRANCH",
 	}
 	saveEnvs := make(map[string]string)
 	for _, key := range cleanEnvs {

--- a/cmd/reviewdog/doghouse.go
+++ b/cmd/reviewdog/doghouse.go
@@ -88,6 +88,7 @@ func postResultSet(ctx context.Context, resultSet map[string][]*reviewdog.CheckR
 			Repo:        ghInfo.Repo,
 			PullRequest: ghInfo.PullRequest,
 			SHA:         ghInfo.SHA,
+			Branch:      ghInfo.Branch,
 			Annotations: as,
 		}
 		g.Go(func() error {

--- a/doghouse/service.go
+++ b/doghouse/service.go
@@ -14,6 +14,9 @@ type CheckRequest struct {
 	// Repository name.
 	// Required.
 	Repo string `json:"repo,omitempty"`
+	// Branch name.
+	// Optional.
+	Branch string `json:"branch,omitempty"`
 
 	// Annotations associated with the repository's commit and Pull Request.
 	Annotations []*Annotation `json:"annotations,omitempty"`


### PR DESCRIPTION
Check Run need branch data and doghouse can get branch data via GitHub
Pull Request API, but if branch data is available in doghouse check request,
we can reduce one GitHub API call.