### PR TITLE
gitlab: add GitLabMergeRequestDiff service separately

### DIFF
--- a/gitlab_mr_commit.go
+++ b/gitlab_mr_commit.go
@@ -14,7 +14,7 @@ import (
 
 var _ CommentService = &GitLabMergeRequestCommitCommenter{}
 
-// GitLabMergeRequestCommitCommenter is a comment and diff service for GitLab MergeRequest.
+// GitLabMergeRequestCommitCommenter is a comment service for GitLab MergeRequest.
 //
 // API:
 //  https://docs.gitlab.com/ce/api/commits.html#post-comment-to-commit

--- a/gitlab_mr_commit_test.go
+++ b/gitlab_mr_commit_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-func TestGitLabPullRequest_Post_Flush_review_api(t *testing.T) {
+func TestGitLabMergeRequestCommitCommenter_Post_Flush_review_api(t *testing.T) {
 	apiCalled := 0
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v4/projects/o/r/merge_requests/14/commits", func(w http.ResponseWriter, r *http.Request) {
@@ -73,7 +73,7 @@ func TestGitLabPullRequest_Post_Flush_review_api(t *testing.T) {
 
 	cli := gitlab.NewClient(nil, "")
 	cli.SetBaseURL(ts.URL + "/api/v4")
-	g, err := NewGitLabMergeRequest(cli, "o", "r", 14, "sha")
+	g, err := NewGitLabMergeRequestCommitCommenter(cli, "o", "r", 14, "sha")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestGitLabPullReqest_workdir(t *testing.T) {
 	cwd, _ := os.Getwd()
 	defer os.Chdir(cwd)
 
-	g, err := NewGitLabMergeRequest(nil, "", "", 0, "")
+	g, err := NewGitLabMergeRequestCommitCommenter(nil, "", "", 0, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -130,7 +130,7 @@ func TestGitLabPullReqest_workdir(t *testing.T) {
 	if err := os.Chdir(subDir); err != nil {
 		t.Fatal(err)
 	}
-	g, _ = NewGitLabMergeRequest(nil, "", "", 0, "")
+	g, _ = NewGitLabMergeRequestCommitCommenter(nil, "", "", 0, "")
 	if g.wd != subDir {
 		t.Fatalf("gitRelWorkdir() = %q, want %q", g.wd, subDir)
 	}

--- a/gitlab_mr_diff.go
+++ b/gitlab_mr_diff.go
@@ -1,0 +1,72 @@
+package reviewdog
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+var _ DiffService = &GitLabMergeRequestDiff{}
+
+type GitLabMergeRequestDiff struct {
+	cli      *gitlab.Client
+	pr       int
+	sha      string
+	projects string
+
+	// wd is working directory relative to root of repository.
+	wd string
+}
+
+func NewGitLabMergeRequestDiff(cli *gitlab.Client, owner, repo string, pr int, sha string) (*GitLabMergeRequestDiff, error) {
+	workDir, err := gitRelWorkdir()
+	if err != nil {
+		return nil, fmt.Errorf("GitLabMergeRequestCommitCommenter needs 'git' command: %v", err)
+	}
+	return &GitLabMergeRequestDiff{
+		cli:      cli,
+		pr:       pr,
+		sha:      sha,
+		projects: owner + "/" + repo,
+		wd:       workDir,
+	}, nil
+}
+
+// Diff returns a diff of MergeRequest. It runs `git diff` locally instead of
+// diff_url of GitLab Merge Request because diff of diff_url is not suited for
+// comment API in a sense that diff of diff_url is equivalent to
+// `git diff --no-renames`, we want diff which is equivalent to
+// `git diff --find-renames`.
+func (g *GitLabMergeRequestDiff) Diff(ctx context.Context) ([]byte, error) {
+	mr, _, err := g.cli.MergeRequests.GetMergeRequest(g.projects, g.pr, nil)
+	if err != nil {
+		return nil, err
+	}
+	targetBranch, _, err := g.cli.Branches.GetBranch(mr.TargetProjectID, mr.TargetBranch, nil)
+	if err != nil {
+		return nil, err
+	}
+	return g.gitDiff(ctx, g.sha, targetBranch.Commit.ID)
+}
+
+func (g *GitLabMergeRequestDiff) gitDiff(ctx context.Context, baseSha string, targetSha string) ([]byte, error) {
+	b, err := exec.Command("git", "merge-base", targetSha, baseSha).Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get merge-base commit: %v", err)
+	}
+	mergeBase := strings.Trim(string(b), "\n")
+	relArg := fmt.Sprintf("--relative=%s", g.wd)
+	bytes, err := exec.Command("git", "diff", relArg, "--find-renames", mergeBase, baseSha).Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run git diff: %v", err)
+	}
+	return bytes, nil
+}
+
+// Strip returns 1 as a strip of git diff.
+func (g *GitLabMergeRequestDiff) Strip() int {
+	return 1
+}

--- a/gitlab_mr_diff.go
+++ b/gitlab_mr_diff.go
@@ -11,6 +11,7 @@ import (
 
 var _ DiffService = &GitLabMergeRequestDiff{}
 
+// GitLabMergeRequestDiff is a diff service for GitLab MergeRequest.
 type GitLabMergeRequestDiff struct {
 	cli      *gitlab.Client
 	pr       int
@@ -21,6 +22,8 @@ type GitLabMergeRequestDiff struct {
 	wd string
 }
 
+// NewGitLabMergeRequestDiff returns a new GitLabMergeRequestDiff service.
+// itLabMergeRequestDiff service needs git command in $PATH.
 func NewGitLabMergeRequestDiff(cli *gitlab.Client, owner, repo string, pr int, sha string) (*GitLabMergeRequestDiff, error) {
 	workDir, err := gitRelWorkdir()
 	if err != nil {

--- a/gitlab_mr_diff_test.go
+++ b/gitlab_mr_diff_test.go
@@ -25,7 +25,7 @@ func TestGitLabMergeRequestDiff_Diff(t *testing.T) {
 		if r.Method != "GET" {
 			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
 		}
-		w.Write([]byte(`{"commit": {"id": "master"}}`))
+		w.Write([]byte(`{"commit": {"id": "HEAD~"}}`))
 	})
 
 	ts := httptest.NewServer(mux)

--- a/gitlab_mr_diff_test.go
+++ b/gitlab_mr_diff_test.go
@@ -1,0 +1,50 @@
+package reviewdog
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func TestGitLabMergeRequestDiff_Diff(t *testing.T) {
+	getMRAPICall := 0
+	getBranchAPICall := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v4/projects/o/r/merge_requests/14", func(w http.ResponseWriter, r *http.Request) {
+		getMRAPICall++
+		if r.Method != "GET" {
+			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
+		}
+		w.Write([]byte(`{"target_project_id": 14, "target_branch": "test-branch"}`))
+	})
+	mux.HandleFunc("/api/v4/projects/14/repository/branches/test-branch", func(w http.ResponseWriter, r *http.Request) {
+		getBranchAPICall++
+		if r.Method != "GET" {
+			t.Errorf("unexpected access: %v %v", r.Method, r.URL)
+		}
+		w.Write([]byte(`{"commit": {"id": "master"}}`))
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	cli := gitlab.NewClient(nil, "")
+	cli.SetBaseURL(ts.URL + "/api/v4")
+
+	g, err := NewGitLabMergeRequestDiff(cli, "o", "r", 14, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := g.Diff(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if getMRAPICall != 1 {
+		t.Errorf("Get GitLab MergeRequest API called %v times, want once", getMRAPICall)
+	}
+	if getBranchAPICall != 1 {
+		t.Errorf("Get GitLab Branch API called %v times, want once", getBranchAPICall)
+	}
+}


### PR DESCRIPTION
We can use GitLabMergeRequestDiff service both for GitLabMergeRequestCommitCommenter and 
new commenter with discussion API https://github.com/haya14busa/reviewdog/issues/157