### PR TITLE
Fix bot could not comment on the merge request created by others

### DIFF
--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -387,13 +387,13 @@ func gitlabBuildWithClient() (*cienv.BuildInfo, *gitlab.Client, error) {
 	return g, client, err
 }
 
-func fetchMergeRequestIDFromCommit(cli *gitlab.Client, repoSlug string, sha string) (id int, err error) {
+func fetchMergeRequestIDFromCommit(cli *gitlab.Client, projectID string, sha string) (id int, err error) {
 	// https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
 	opt := &gitlab.ListProjectMergeRequestsOptions{
 		State:   gitlab.String("opened"),
 		OrderBy: gitlab.String("updated_at"),
 	}
-	mrs, _, err := cli.MergeRequests.ListProjectMergeRequests(repoSlug, opt)
+	mrs, _, err := cli.MergeRequests.ListProjectMergeRequests(projectID, opt)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/reviewdog/main.go
+++ b/cmd/reviewdog/main.go
@@ -375,7 +375,7 @@ func gitlabBuildWithClient() (*cienv.BuildInfo, *gitlab.Client, error) {
 	}
 
 	if g.PullRequest == 0 {
-		prNr, err := fetchMergeRequestIDFromCommit(client, g.SHA)
+		prNr, err := fetchMergeRequestIDFromCommit(client, g.Owner + "/" + g.Repo, g.SHA)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -387,13 +387,13 @@ func gitlabBuildWithClient() (*cienv.BuildInfo, *gitlab.Client, error) {
 	return g, client, err
 }
 
-func fetchMergeRequestIDFromCommit(cli *gitlab.Client, sha string) (id int, err error) {
+func fetchMergeRequestIDFromCommit(cli *gitlab.Client, repoSlug string, sha string) (id int, err error) {
 	// https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
-	opt := &gitlab.ListMergeRequestsOptions{
+	opt := &gitlab.ListProjectMergeRequestsOptions{
 		State:   gitlab.String("opened"),
 		OrderBy: gitlab.String("updated_at"),
 	}
-	mrs, _, err := cli.MergeRequests.ListMergeRequests(opt)
+	mrs, _, err := cli.MergeRequests.ListProjectMergeRequests(repoSlug, opt)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
- gitlab-mr-discussion uses the [List merge requests API](https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests).
- List merge requests API is lists the merge requests that created by me.
- But, as a situation we should want to list the merge requests in the project.
- If we want to list the merge requests in the project, there is a [List project merge requests API](https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests)